### PR TITLE
Add job to preview infra changes to prod with what-if

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -128,21 +128,6 @@ jobs:
         run: |
           echo "BRANCH_NAME=$(echo ${GITHUB_REF#refs/heads/} | sed 's/\//_/g')" >> $GITHUB_ENV
 
-      - name: Preview infrastructure changes
-        run: >
-          az deployment sub what-if \
-            --name 'spacegamedeploy-${{ env.ENVIRONMENTNAME }}' \
-            --location '${{ env.LOCATION }}' \
-            --template-file IaC/main.bicep \
-            --parameters appName='${{ env.APPNAME }}' \
-                         environmentName=${{ env.ENVIRONMENTNAME }} \
-                         branchName='-${{ env.BRANCH_NAME }}' \
-                         registryName='${{ env.REGISTRYNAME }}' \
-                         tag='${{ github.sha }}' \
-                         dbUserName='${{ secrets.DBUSERNAME }}' \
-                         dbPassword='${{ secrets.DBPASSWORD }}' \
-                         devEnv='${{ env.DEVENV }}'
-
       - name: Deploy infrastructure
         run: >
           az deployment sub create \

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -106,8 +106,6 @@ jobs:
           Write-Host 'Total Tests PASSED.....:  ${{ steps.IaCTests.outputs.passed_count }}'
           Write-Host 'Total Tests FAILED.....:  ${{ steps.IaCTests.outputs.failed_count }}'
          
-
-
   deployDev:
     name: Deploy to Dev
     environment:
@@ -279,6 +277,37 @@ jobs:
           cd LoadTests        
           ${JMETER_HOME}/bin/./jmeter -n -t LoadTest.jmx -o Results.xml -Jhostname=${{ env.SITE_URL }}
 
+  previewIaCProd:
+    name: Preview IaC Changes
+    runs-on: ubuntu-20.04
+    environment:
+      name: prod-preview
+    env:
+      ENVIRONMENTNAME: prod-preview
+      DEVENV: false
+    needs: [testLoad, testFunctional]
+    steps:
+      - uses: actions/checkout@master
+
+      - name: Azure authentication
+        uses: azure/login@v1
+        with:
+          creds: ${{ secrets.AZURE_CREDENTIALS }}
+
+      - name: Preview infrastructure changes
+        run: >
+          az deployment sub what-if \
+            --name 'spacegamedeploy-${{ env.ENVIRONMENTNAME }}' \
+            --location '${{ env.LOCATION }}' \
+            --template-file IaC/main.bicep \
+            --parameters appName='${{ env.APPNAME }}' \
+                         environmentName=${{ env.ENVIRONMENTNAME }} \
+                         registryName='${{ env.REGISTRYNAME }}' \
+                         tag='${{ github.sha }}' \
+                         dbUserName='${{ secrets.DBUSERNAME }}' \
+                         dbPassword='${{ secrets.DBPASSWORD }}' \
+                         devEnv='${{ env.DEVENV }}'
+
   deployProd:
     name: Deploy to Prod
     runs-on: ubuntu-20.04
@@ -288,7 +317,7 @@ jobs:
     env:
       ENVIRONMENTNAME: prod
       DEVENV: false
-    needs: [testLoad, testFunctional]
+    needs: [previewIaCProd]
     steps:
       - uses: actions/checkout@master
 
@@ -310,7 +339,7 @@ jobs:
                          dbUserName='${{ secrets.DBUSERNAME }}' \
                          dbPassword='${{ secrets.DBPASSWORD }}' \
                          devEnv='${{ env.DEVENV }}'
-
+                         
       - uses: actions/download-artifact@v2
         name: Download dacpac from build
         with:

--- a/IaC/main.bicep
+++ b/IaC/main.bicep
@@ -9,6 +9,7 @@ param appName string
   'dev'
   'test'
   'prod'
+  'prod-preview'
 ])
 param environmentName string
 @description('Source branch of PR - passed in via pipeline for dev environment')

--- a/IaC/webapp.bicep
+++ b/IaC/webapp.bicep
@@ -4,6 +4,7 @@
   'dev'
   'test'
   'prod'
+  'prod-preview'
 ])
 param environmentName string
 @description('Primary location for resources')

--- a/Readme.md
+++ b/Readme.md
@@ -1,11 +1,12 @@
 # Demo.SpaceGamevNext
+
 ![spaceGame](https://user-images.githubusercontent.com/6855361/111529516-3efed480-8730-11eb-9a73-a1f4727f3b21.PNG)
 
 The next iteration of [Demo.SpaceGame](https://github.com/MarcusFelling/Demo.SpaceGame), now using containers and GitHub Actions 🚀!
 
 The Space Game website is a .NET 5 web app that's deployed to ☁️ Azure Web App for Containers and Azure SQL ☁️. The infrastructure is deployed using [Azure Bicep](https://github.com/Azure/bicep) 💪, and the application is tested using Selenium for functional tests and JMeter for load tests.
 
-# CI/CD Workflow
+## CI/CD Workflow
 
 ![Main branch](https://github.com/MarcusFelling/Demo.SpaceGamevNext/actions/workflows/pipeline.yml/badge.svg?branch=main)
 
@@ -13,8 +14,8 @@ The Space Game website is a .NET 5 web app that's deployed to ☁️ Azure Web A
 2. The build stage of the pipeline ensures all projects successfully compile and tests pass.
 3. The pipeline will provision a new website for your branch (branch name will be in URL), that can be used for exploratory testing or remote debugging. The URL of the new website will post to the Environments section of the PR. Click "View Deployment" to open the site:
 ![environment](https://user-images.githubusercontent.com/6855361/111533320-a61e8800-8734-11eb-93d4-b2f4883313b3.PNG)
-5. Meanwhile, the pipeline will execute functional and load tests in a testing environment.
-6. If all tests are successful, the pipeline will run [what-if](https://docs.microsoft.com/en-us/azure/azure-resource-manager/templates/deploy-what-if?tabs=azure-powershell) to preview any infrastructure changes then wait for manual review/approval before deploying to production.
-7. After the PR is merged, a final [workflow](https://github.com/MarcusFelling/Demo.SpaceGamevNext/blob/main/.github/workflows/cleanup.yml) will run to clean up the development environment.
+4. Meanwhile, the pipeline will execute functional and load tests in a testing environment.
+5. If all tests are successful, the pipeline will run [what-if](https://docs.microsoft.com/en-us/azure/azure-resource-manager/templates/deploy-what-if?tabs=azure-powershell) to preview any infrastructure changes then wait for manual review/approval before deploying to production.
+6. After the PR is merged, a final [workflow](https://github.com/MarcusFelling/Demo.SpaceGamevNext/blob/main/.github/workflows/cleanup.yml) will run to clean up the development environment.
 
 ![pipeline](https://user-images.githubusercontent.com/6855361/111533722-1cbb8580-8735-11eb-95e7-df517da9a9cc.PNG)

--- a/Readme.md
+++ b/Readme.md
@@ -15,7 +15,7 @@ The Space Game website is a .NET 5 web app that's deployed to ☁️ Azure Web A
 3. The pipeline will provision a new website for your branch (branch name will be in URL), that can be used for exploratory testing or remote debugging. The URL of the new website will post to the Environments section of the PR. Click "View Deployment" to open the site:
 ![environment](https://user-images.githubusercontent.com/6855361/111533320-a61e8800-8734-11eb-93d4-b2f4883313b3.PNG)
 4. Meanwhile, the pipeline will execute functional and load tests in a testing environment.
-5. If all tests are successful, the pipeline will run [what-if](https://docs.microsoft.com/en-us/azure/azure-resource-manager/templates/deploy-what-if?tabs=azure-powershell) to preview any infrastructure changes then wait for manual review/approval before deploying to production.
+5. If all tests are successful, the pipeline will run [what-if](https://docs.microsoft.com/azure/azure-resource-manager/templates/deploy-what-if?tabs=azure-powershell) to preview any infrastructure changes then wait for manual review/approval before deploying to production.
 6. After the PR is merged, a final [workflow](https://github.com/MarcusFelling/Demo.SpaceGamevNext/blob/main/.github/workflows/cleanup.yml) will run to clean up the development environment.
 
 ![pipeline](https://user-images.githubusercontent.com/6855361/111533722-1cbb8580-8735-11eb-95e7-df517da9a9cc.PNG)

--- a/Readme.md
+++ b/Readme.md
@@ -14,7 +14,7 @@ The Space Game website is a .NET 5 web app that's deployed to ☁️ Azure Web A
 3. The pipeline will provision a new website for your branch (branch name will be in URL), that can be used for exploratory testing or remote debugging. The URL of the new website will post to the Environments section of the PR. Click "View Deployment" to open the site:
 ![environment](https://user-images.githubusercontent.com/6855361/111533320-a61e8800-8734-11eb-93d4-b2f4883313b3.PNG)
 5. Meanwhile, the pipeline will execute functional and load tests in a testing environment.
-6. If all tests are successful, the pipeline will wait for manual approval before deploying to production.
+6. If all tests are successful, the pipeline will run [what-if](https://docs.microsoft.com/en-us/azure/azure-resource-manager/templates/deploy-what-if?tabs=azure-powershell) to preview any infrastructure changes then wait for manual review/approval before deploying to production.
 7. After the PR is merged, a final [workflow](https://github.com/MarcusFelling/Demo.SpaceGamevNext/blob/main/.github/workflows/cleanup.yml) will run to clean up the development environment.
 
 ![pipeline](https://user-images.githubusercontent.com/6855361/111533722-1cbb8580-8735-11eb-95e7-df517da9a9cc.PNG)


### PR DESCRIPTION
Environment prod-preview is being added in order to require a manual approval after what-if is run. Currently not possible to require approver between steps e.g. single prod job, run what-if, pause for approval, continue deployment.