### PR TITLE
Upgrade to premium ACR sku

### DIFF
--- a/IaC/main.bicep
+++ b/IaC/main.bicep
@@ -46,7 +46,7 @@ module registry 'registry.bicep' = {
   scope: acrrg
   params: {
     registry: registryName
-    registrySku: 'Standard'
+    registrySku: 'Premium'
   }
 }
 


### PR DESCRIPTION
- Upgrading from Standard in order to use geo-replication for managing a single registry across multiple regions.